### PR TITLE
Fix for lost devices of nvidia containers

### DIFF
--- a/pkgs/containers/l4t-csv.nix
+++ b/pkgs/containers/l4t-csv.nix
@@ -2,7 +2,7 @@
 
   l4t-csv = if l4tVersion == "36.4.3" then
     "cat etc/nvidia-container-runtime/host-files-for-container.d/devices.csv > etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv \
-     cat etc/nvidia-container-runtime/host-files-for-container.d/drivers.csv > etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv"
+     cat etc/nvidia-container-runtime/host-files-for-container.d/drivers.csv >> etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv"
   else if l4tVersion == "35.6.0" then
     ""
   else


### PR DESCRIPTION
###### Description of changes

The script creating the l4t.csv to process the nvidia container mappings mistakenly overridden the devices. 
The fix preserves the devices in l4t.csv

###### Testing

In the final build the resultant l4t.csv can be searched in /nix/store with 
`find /nix/store -name *l4t.csv` then the contents can be checked to ensure the devices are listed inside.