### PR TITLE
Hai's Cuda fix for redistSystem definition

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -21,7 +21,11 @@ let
     _cuda.db.allSortedCudaCapabilities;
   hasJetsonCudaCapability =
     intersectLists jetsonCudaCapabilities (final.config.cudaCapabilities or [ ]) != [ ];
-  redistSystem = _cuda.lib.getRedistSystem hasJetsonCudaCapability final.stdenv.hostPlatform.system;
+  redistSystem = _cuda.lib.getRedistSystem {
+    cudaCapabilities = if hasJetsonCudaCapability then jetsonCudaCapabilities else [];
+    cudaMajorMinorVersion = final.cudaPackages.cudaMajorMinorVersion or "11.4";
+    system = final.stdenv.hostPlatform.system;
+  };
 in
 {
   nvidia-jetpack5 = import ./mk-overlay.nix


### PR DESCRIPTION
Connor Baker changed the jetpack-nixos and cuda support in that library in order to support Thor and Jetpack 7. During this process he created a huge PR including this commit for _cuda.lib.getRedistSystem: refactor for CUDA 13 support.
(https://github.com/NixOS/nixpkgs/commit/d637c4036495e2fc0e158614658f690ad183ff46) and this broke down the cuda support on many nixos configurations using nixpkgs and jetpack-nixos. 
This change is introduced by Hai To during his work on fog-ghaf fixing the issues about querying the system type depending on cuda support. 

###### Testing

No tests but even if Cuda is enabled your builds are not broken anymore in nixpkgs with this definition in Orin devices.
