### PR TITLE
fix: cherry-pick upstream fix for bootOrder -> initialBootOrder usage

### DIFF
--- a/pkgs/cuda-packages-11-4/nsight_compute_host.nix
+++ b/pkgs/cuda-packages-11-4/nsight_compute_host.nix
@@ -3,6 +3,13 @@
 , dbus
 , expat
 , fontconfig
+, libice
+, libsm
+, libxcb
+, libxcomposite
+, libxdamage
+, libxfixes
+, libxtst
 , ncurses5
 , noto-fonts
 , nsight_compute_target
@@ -12,7 +19,6 @@
 , qt6
 , stdenv
 , xkeyboard_config
-, xorg
 ,
 }:
 let
@@ -65,18 +71,18 @@ buildFHSEnv {
     (
       [
         ncurses5
-        xorg.libxcb
+        libxcb
         fontconfig
         noto-fonts
         dbus
         nss
-        xorg.libXcomposite
-        xorg.libXdamage
+        libxcomposite
+        libxdamage
         alsa-lib
-        xorg.libXtst
-        xorg.libSM
-        xorg.libICE
-        xorg.libXfixes
+        libxtst
+        libsm
+        libice
+        libxfixes
         xkeyboard_config
         expat
         nspr

--- a/pkgs/cuda-packages-11-4/nsight_systems_host.nix
+++ b/pkgs/cuda-packages-11-4/nsight_systems_host.nix
@@ -3,6 +3,13 @@
 , dbus
 , expat
 , fontconfig
+, libice
+, libsm
+, libxcb
+, libxcomposite
+, libxdamage
+, libxfixes
+, libxtst
 , ncurses5
 , noto-fonts
 , nsight_systems_target
@@ -14,7 +21,6 @@
 , requireFile
 , stdenv
 , xkeyboard_config
-, xorg
 ,
 }:
 let
@@ -86,18 +92,18 @@ buildFHSEnv {
     (
       [
         ncurses5
-        xorg.libxcb
+        libxcb
         fontconfig
         noto-fonts
         dbus
         nss
-        xorg.libXcomposite
-        xorg.libXdamage
+        libxcomposite
+        libxdamage
         alsa-lib
-        xorg.libXtst
-        xorg.libSM
-        xorg.libICE
-        xorg.libXfixes
+        libxtst
+        libsm
+        libice
+        libxfixes
         xkeyboard_config
         expat
         nspr

--- a/pkgs/l4t/driverDebs.nix
+++ b/pkgs/l4t/driverDebs.nix
@@ -3,7 +3,8 @@
 , debs
 , lib
 , libgcc
-, xorg
+, libx11
+, libxext
 }:
 let
   findDriverDebNames = majorVersion: lib.filter (lib.hasSuffix "-${majorVersion}") (lib.attrNames debs.common);
@@ -14,10 +15,10 @@ let
 
     buildInputs = lib.attrByPath [ pname ] [ ] {
       libnvidia-compute-580 = [ driverDebs.libnvidia-decode-580 libgcc ];
-      libnvidia-decode-580 = [ xorg.libX11 xorg.libXext ];
+      libnvidia-decode-580 = [ libx11 libxext ];
       libnvidia-encode-580 = [ driverDebs.libnvidia-decode-580 ];
-      libnvidia-fbc1-580 = [ xorg.libX11 xorg.libXext ];
-      libnvidia-gl-580 = [ xorg.libX11 xorg.libXext libgcc driverDebs.libnvidia-gpucomp-580 ];
+      libnvidia-fbc1-580 = [ libx11 libxext ];
+      libnvidia-gl-580 = [ libx11 libxext libgcc driverDebs.libnvidia-gpucomp-580 ];
     };
   });
 in

--- a/pkgs/l4t/l4t-3d-core.nix
+++ b/pkgs/l4t/l4t-3d-core.nix
@@ -4,7 +4,9 @@
 , l4t-core
 , lib
 , libglvnd
-, xorg
+, libx11
+, libxcb
+, libxext
 ,
 }:
 # TODO: Split this package up into subpackages similar to what is done in meta-tegra: vulkan, glx, egl, etc
@@ -60,5 +62,5 @@ buildFromDebs {
     rm -r share/doc
   '';
 
-  appendRunpaths = [ "${placeholder "out"}/lib" ] ++ builtins.map (p: (lib.getLib p) + "/lib") [ libglvnd xorg.libX11 xorg.libXext xorg.libxcb ];
+  appendRunpaths = [ "${placeholder "out"}/lib" ] ++ builtins.map (p: (lib.getLib p) + "/lib") [ libglvnd libx11 libxext libxcb ];
 }

--- a/pkgs/samples/graphics-demos.nix
+++ b/pkgs/samples/graphics-demos.nix
@@ -8,13 +8,12 @@
 , libxkbcommon
 , stdenv
 , wayland
-, xorg
+, libx11
+, libxau
 , l4tAtLeast
 }:
 # TODO: Add wayland and x11 tests for graphics demos....
 let
-  inherit (xorg) libX11 libXau;
-
   repo = if l4tAtLeast "38" then "som" else "t234";
 in
 stdenv.mkDerivation {
@@ -25,7 +24,7 @@ stdenv.mkDerivation {
   sourceRoot = "source/usr/src/nvidia/graphics_demos";
 
   nativeBuildInputs = [ dpkg ];
-  buildInputs = [ libX11 libGL libXau libdrm wayland libxkbcommon libffi ];
+  buildInputs = [ libx11 libGL libxau libdrm wayland libxkbcommon libffi ];
 
   postPatch = ''
     substituteInPlace Makefile.l4tsdkdefs \

--- a/pkgs/samples/multimedia-samples.nix
+++ b/pkgs/samples/multimedia-samples.nix
@@ -20,7 +20,7 @@
 , python3
 , vulkan-headers
 , vulkan-loader
-, xorg
+, libx11
 }:
 # https://docs.nvidia.com/jetson/l4t-multimedia/group__l4t__mm__test__group.html
 let
@@ -30,7 +30,6 @@ let
     cudatoolkit
     tensorrt
     ;
-  inherit (xorg) libX11;
 in
 backendStdenv.mkDerivation {
   __structuredAttrs = true;
@@ -51,7 +50,7 @@ backendStdenv.mkDerivation {
     l4t-multimedia
     libdrm
     libglvnd
-    libX11
+    libx11
     opencv
     pango
     tensorrt


### PR DESCRIPTION
Cherry-pick of upstream commit d537752 ("flash-script: Update usage of bootOrder -> intialBootOrder").

Commit c5cd5a0 renamed the option `hardware.nvidia-jetpack.firmware.bootOrder` to `initialBootOrder` and added a `mkRenamedOptionModule` compat alias, but forgot to update two usage sites in the implementation. This causes a trace warning on every evaluation:

```
trace: Obsolete option `hardware.nvidia-jetpack.firmware.bootOrder' is used.
It was renamed to `hardware.nvidia-jetpack.firmware.initialBootOrder'.
```

This was already fixed upstream in anduril/jetpack-nixos@d537752.