### PR TITLE
fix: restore l4t-xusb-firmware for L4T 36.x

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -316,7 +316,7 @@ in
       ] ++ lib.optionals (lib.versionOlder cfg.majorVersion "7") [
         # Optional, but needed for pva_auth_allowlist firmware file used by VPI2
         cudaPackages.vpi-firmware
-      ] ++ lib.optionals (l4tOlder "36") [
+      ] ++ lib.optionals (l4tOlder "38") [
         l4t-xusb-firmware # usb firmware also present in linux-firmware package, but that package is huge and has much more than needed
       ] ++ lib.optionals (l4tAtLeast "38") (
         let

--- a/pkgs/l4t/default.nix
+++ b/pkgs/l4t/default.nix
@@ -33,10 +33,13 @@ in
 } // lib.optionalAttrs (l4tAtLeast "36") {
   inherit (packages) l4t-nvml;
   nvidia-smi = packages.l4t-nvml;
+} // lib.optionalAttrs (l4tOlder "38") {
+  inherit (packages)
+    l4t-xusb-firmware
+    ;
 } // lib.optionalAttrs (l4tOlder "36") {
   inherit (packages)
     l4t-cupva
-    l4t-xusb-firmware
     ;
 } // lib.optionalAttrs (l4tAtLeast "38") {
   inherit (packages)


### PR DESCRIPTION
The firmware condition was changed from `l4tOlder "38"` to `l4tOlder "36"` which excludes L4T 36.x (e.g. 36.5.0) from getting USB firmware.

L4T 36.5.0 falls through both conditions:
- `l4tOlder "36"` = false (36.5.0 >= 36)
- `l4tAtLeast "38"` = false (36.5.0 < 38)

Result: no USB firmware at all, which breaks USB-ethernet and WiFi PCI passthrough on Jetson Orin AGX.

Found while investigating https://github.com/tiiuae/ghaf/pull/1849#issuecomment-4142781329